### PR TITLE
Fix camera freezes on iOS by using a 0px video

### DIFF
--- a/src/GameboyCamera/camera.tsx
+++ b/src/GameboyCamera/camera.tsx
@@ -1,4 +1,10 @@
 import React, { MutableRefObject, useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+
+const VideoBuffer = styled.video`
+  width: 0;
+  height: 0;
+`;
 
 type CameraProps = {
   deviceId?: string;
@@ -51,18 +57,16 @@ const Camera = React.forwardRef(
     }, [deviceId]);
 
     return (
-      <>
-        <video
-          ref={videoRef}
-          onCanPlay={() => {
-            videoRef.current?.play();
-          }}
-          autoPlay
-          playsInline
-          muted
-          {...props}
-        />
-      </>
+      <VideoBuffer
+        ref={videoRef}
+        onCanPlay={() => {
+          videoRef.current?.play();
+        }}
+        autoPlay
+        playsInline
+        muted
+        {...props}
+      />
     );
   },
 );

--- a/src/GameboyCamera/index.tsx
+++ b/src/GameboyCamera/index.tsx
@@ -182,7 +182,6 @@ const GameboyCamera = () => {
           frameInterval={interval}
           onSetFacing={(f) => (facing.current = f)}
           onCameraStarted={updateDevices}
-          hidden
         />
         <ImageCanvas scene={composite} />
         <Title>LAME BOY camera</Title>


### PR DESCRIPTION
On iOS, using a hidden `<video>` element causes the camera to freeze and turn off after a few seconds. It is not clear why this happens but might have to do with Safari's heuristics to disallow some autoplaying videos. Neither Safari's logs nor the iOS system logs explain the cause, but removing the `video.play()` call keeps the camera on, so the issue seems related to the video element.

Regardless of the cause, using a 0px video solves the issue. (Using a video element that's not part of the DOM tree should also work.)

Tested by running `yarn dev`, starting a network tunnel, and loading the URL from an iPhone and seeing that the camera stream works as expected. Also tested on desktop Chrome.