### PR TITLE
Fix tearDown routine

### DIFF
--- a/src/GameboyCamera/camera.tsx
+++ b/src/GameboyCamera/camera.tsx
@@ -22,14 +22,12 @@ const Camera = React.forwardRef(
     const [stream, setStream] = useState<MediaStream>();
 
     const tearDown = () => {
-      stream?.getTracks().forEach((t) => t.stop());
-      stream?.getAudioTracks().forEach((t) => t.stop());
+      stream?.getVideoTracks().forEach((t) => t.stop());
       setStream(undefined);
       videoRef.current.srcObject = undefined;
     };
 
     const setUp = async () => {
-      tearDown();
       const s = await navigator.mediaDevices.getUserMedia({
         audio: false,
         video: {
@@ -47,7 +45,7 @@ const Camera = React.forwardRef(
 
     useEffect(() => {
       setUp();
-      return tearDown();
+      return tearDown;
     }, [deviceId]);
 
     return (


### PR DESCRIPTION
The effect hook in the Camera component called `tearDown()` when setting up instead of returning a callback to be invoked when the Camera switches which camera it uses.

With this, `setUp` doesn't need to call `tearDown` anymore since React will properly run the teardown callback before setting up the new camera.

Lastly, `tearDown` stopped all media streams and then the audio streams again, but it only needs to stop the video streams.

Tested by loading the site, giving it permission to access the camera, and verified the stream shows up as expected. Switched cameras via the dropdown menu and saw the viewfinder switch cameras. Switched back and saw the viewfinder update again.